### PR TITLE
It is better to use the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sqlx-rqlite"
 #documentation = "https://docs.rs/sqlx"
 description = "rqlite driver implementation for SQLx. intended for use with sqlx; see the `sqlx` crate for details."
-homepage = "https://github.com/HaHa421/sqlx-rqlite"
+repository = "https://github.com/HaHa421/sqlx-rqlite"
 version = "0.1.3"
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.